### PR TITLE
Refactor, remove prefix/cURI usage.

### DIFF
--- a/contexts/veres-one-v1.jsonld
+++ b/contexts/veres-one-v1.jsonld
@@ -1,19 +1,13 @@
 {
   "@context": {
-    "@version": 1.1,
+    "Elector": "https://w3id.org/webledger#Elector",
+    "RecoveryElector": "https://w3id.org/webledger#RecoveryElector",
+    "ValidatorParameterSet": "https://w3id.org/webledger#ValidatorParameterSet",
 
-    "v1": "https://w3id.org/veres-one#",
-    "wl": "https://w3id.org/webledger#",
-    "xsd": "http://www.w3.org/2001/XMLSchema#",
-
-    "Elector": "wl:Elector",
-    "RecoveryElector": "wl:RecoveryElector",
-    "ValidatorParameterSet": "wl:ValidatorParameterSet",
-
-    "allowedServiceBaseUrl": {"@id": "v1:allowedServiceBaseUrl", "@type": "@id", "@container": "@set"},
-    "blockHeight": "wl:blockHeight",
-    "elector": {"@id": "wl:elector", "@type": "@id"},
-    "electorPool": {"@id": "wl:electorPool", "@type": "@id", "@container": "@set"},
-    "maximumElectorCount": {"@id": "wl:maximumElectorCount", "@type": "xsd:integer"}
+    "allowedServiceBaseUrl": {"@id": "https://w3id.org/veres-one#allowedServiceBaseUrl", "@type": "@id", "@container": "@set"},
+    "blockHeight": "https://w3id.org/webledger#blockHeight",
+    "elector": {"@id": "https://w3id.org/webledger#elector", "@type": "@id"},
+    "electorPool": {"@id": "https://w3id.org/webledger#electorPool", "@type": "@id", "@container": "@set"},
+    "maximumElectorCount": {"@id": "https://w3id.org/webledger#maximumElectorCount", "@type": "http://www.w3.org/2001/XMLSchema#integer"}
   }
 }

--- a/lib/constants.js
+++ b/lib/constants.js
@@ -3,4 +3,10 @@
  */
 'use strict';
 
-exports.VERES_ONE_CONTEXT_V1_URL = 'https://w3id.org/veres-one/v1';
+const VERES_ONE_CONTEXT_V1_URL = 'https://w3id.org/veres-one/v1';
+
+module.exports = {
+  VERES_ONE_CONTEXT_V1_URL,
+  CONTEXT_URL: VERES_ONE_CONTEXT_V1_URL,
+  CBORLD_CODEC_VALUE: 0x18
+};

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "webpack-cli": "^3.3.2"
   },
   "scripts": {
-    "prepublish": "npm run build",
+    "prepare": "npm run build",
     "build": "webpack && rollup -c"
   }
 }


### PR DESCRIPTION
This is the current Veres One context being used in `bedrock-did-io`, and all our other libs.